### PR TITLE
Very tiny change

### DIFF
--- a/content/blocks/storage/core-forum.hjson
+++ b/content/blocks/storage/core-forum.hjson
@@ -1,5 +1,5 @@
 type: CoreBlock
-name: "Forum"
+name: "Core: Forum"
 description: The main base, when destroyed a sector is lost.
 size: 4
 squareSprite: false


### PR DESCRIPTION
makes the forum core in line to the current naming style of cores
eg:
core: shard
now its core: forum instead of just forum